### PR TITLE
xgboost: add clipping of loss values to the float32 limits

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,6 +11,7 @@ disable=C0103,C0301,R0801,W1514,W1505
 
 [IMPORTS]
 ignored-modules=
+known-third-party=xgboost
 
 [DESIGN]
 # min-public-methods=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 ensure_newline_before_comments=True
+known_third_party=xgboost
 
 [black]
 exclude = "scripts/whitelists/"

--- a/tests/fixtures/test_models.py
+++ b/tests/fixtures/test_models.py
@@ -15,13 +15,16 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """Module containing simple models used for testing."""
+from typing import Sequence
 
 import numpy as np
 from numpy.typing import NDArray
 
-
 # Just an iid normal sampling
-def NormalMV(theta: NDArray, N: int, seed: int) -> NDArray:
+from scipy.special import softmax
+
+
+def NormalMV(theta: Sequence, N: int, seed: int) -> NDArray:
     """Sample from a normal distribution with adjustable mean and variance.
 
     Args:
@@ -36,3 +39,62 @@ def NormalMV(theta: NDArray, N: int, seed: int) -> NDArray:
 
     y = np.random.normal(theta[0], theta[1], N)
     return np.atleast_2d(y).T
+
+
+def BH4(theta: Sequence[float], N: int, seed: int) -> NDArray:
+    """Model from Brock and Hommes 1998.
+
+    4.3 Four belief types: Fundamentalists versus trend versus bias
+
+    This function implements the parametrisation of the model proposed in Platt (2020)
+
+    theta structure:
+    [g1,b1, g2,b2, g3,b3, g4,b4]
+
+    From Donovan Platt 2019: (experiments run)
+    [g2, b2] and [g2, b2, g3, b3], with all parameters assumed to lie in the
+    interval [0, 1], with the exception of b3, which we assume lies in the interval [−1, 0].
+    [g1,b1,  g2,b2,  g3,b3,  g4,b4,  r,β] = [0,0,  0.9,0.2,  0.9,-0.2,  1.01,0,  0.01,1]
+
+    Args:
+        theta: parameters
+        N: length of simulation
+        seed: random seed
+
+    Returns:
+        simulated series
+    """
+    np.random.seed(seed=seed)
+
+    R = 1.01
+    beta = 120
+    sigma = 0.04
+
+    # BH noise:
+    x_lag2 = 0.05
+    x_lag1 = 0.10
+
+    x = np.zeros(N + 2)
+    n = np.full(4, 0.25)
+    g = np.array([0.0, 0.9, 0.9, 1.01])
+    b = np.array([0.0, 0.2, -0.2, 0.00])
+
+    x[0] = x_lag2
+    x[1] = x_lag1
+
+    for i in range(int(len(theta) / 2)):
+        g[i] = theta[i * 2]
+        b[i] = theta[i * 2 + 1]
+
+    for t in range(2, N + 1):
+        expectation = np.add(g * x[t - 1], b)
+        weighted_exp = np.multiply(n, expectation)
+        dividend_noise = np.random.normal(0, sigma, 1)
+        x[t] = (np.sum(weighted_exp) + dividend_noise) / R
+
+        left_factor = x[t] - R * x[t - 1]
+        right_factor = np.add(g * x[t - 2], b) - R * x[t - 1]
+
+        n = softmax(beta * left_factor * right_factor)
+
+    return np.atleast_2d(x[2:]).T

--- a/tests/test_samplers/test_xgboost.py
+++ b/tests/test_samplers/test_xgboost.py
@@ -15,9 +15,16 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 """This module contains tests for the xgboost sampler."""
 import numpy as np
+import pytest
+import xgboost as xgb
 
+from black_it.calibrator import Calibrator
+from black_it.loss_functions.msm import MethodOfMomentsLoss
+from black_it.samplers.halton import HaltonSampler
 from black_it.samplers.xgboost import XGBoostSampler
 from black_it.search_space import SearchSpace
+
+from ..fixtures.test_models import BH4  # type: ignore
 
 expected_params = np.array([[0.24, 0.26], [0.26, 0.02], [0.08, 0.24], [0.15, 0.15]])
 
@@ -47,3 +54,50 @@ def test_xgboost_2d() -> None:
     new_params = sampler.sample(param_grid, xys, losses)
 
     assert np.allclose(expected_params, new_params)
+
+
+def test_clip_losses() -> None:
+    """Test the xgboost _clip_losses method."""
+    true_params = [
+        0.0,  # g1
+        0.0,  # b1
+        0.9,  # g2
+        0.2,  # b2
+        0.9,  # g3
+        -0.2,  # b3
+        1.01,  # g4
+        0.01,
+    ]  # b4
+
+    parameter_bounds = [
+        [0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 1.0, 0.0],  # lower bounds
+        [0.1, 0.1, 1.0, 1.0, 1.0, 0.0, 1.1, 1.0],
+    ]  # upper bounds
+
+    precisions = [0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
+
+    target_series = BH4(true_params, N=1000, seed=0)
+
+    halton = HaltonSampler(batch_size=3)
+    xgboost = XGBoostSampler(batch_size=3)
+
+    loss = MethodOfMomentsLoss()
+
+    cal = Calibrator(
+        real_data=target_series,
+        samplers=[halton, xgboost],
+        loss_function=loss,
+        model=BH4,
+        parameters_bounds=parameter_bounds,
+        parameters_precision=precisions,
+        ensemble_size=3,
+        random_state=0,
+    )
+
+    # the calibration breaks due to losses exceeding the limits of float32
+
+    with pytest.raises(
+        xgb.core.XGBoostError,
+        match=r"Label contains NaN, infinity or a value too large",
+    ):
+        _, losses = cal.calibrate(1)


### PR DESCRIPTION
## Proposed changes

Internally the XGBoost routine operates a conversion to float32, and this fails if the absolute values of the loss are exceedingly large. This commit adds a simple clipping operation before the loss values are passed to the XGBoost package.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

