### PR TITLE
`tox.ini` refactoring

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,13 @@ jobs:
 #      run: ...
     - name: Unit tests and coverage
       run: |
-        tox -e py${{ matrix.python-version }} -- -m 'not e2e'
+        pyver=$(echo ${{ matrix.python_version }} | tr -d ".")
+        tox -e py${pyver} -- -m 'not e2e'
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: false
     - name: Notebook tests
       run: |
-        tox -e py${{ matrix.python_version }}-nb
+        pyver=$(echo ${{ matrix.python_version }} | tr -d ".")
+        tox -e py${pyver}-nb

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = bandit, safety, check-copyright, black-check, isort-check, vulture, flake8, mypy, pylint, py3.10, py3.9, py3.8, py3.8-nb, docs
+envlist = bandit, safety, check-copyright, black-check, isort-check, vulture, flake8, mypy, pylint, py3{8,9,10}, docs
 
 [tox:.package]
 # note tox will use the same python version as under what tox is installed to package
@@ -29,16 +29,12 @@ commands =
         --cov-report=html \
         --cov-report=term {posargs}
 
-[testenv:py3.8]
-basepython = python3.8
+[testenv:py{38,39,310}]
+commands =
+    {[testenv]commands}
 
-[testenv:py3.9]
-basepython = python3.9
-
-[testenv:py3.10]
-basepython = python3.10
-
-[testenv:py3.8-nb]
+# test environment for notebooks
+[testenv:py{38,39,310}-nb]
 basepython = python3.8
 deps =
     pytest>=7.1.2,<7.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -44,8 +44,7 @@ deps =
     pytest>=7.1.2,<7.2.0
     mesa>=0.9.0,<0.10.0
     nbmake>=1.3.0,<1.4.0
-commands:
-    pytest examples/tests_on_toy_model.ipynb --nbmake --nbmake-timeout=300
+commands = pytest examples/tests_on_toy_model.ipynb --nbmake --nbmake-timeout=300
 
 [testenv:flake8]
 skip_install = True


### PR DESCRIPTION
## Proposed changes

This PR applies two major changes to the `tox.ini` specification.

- 1f26c4a3dbeb49bc85753a5c32b66081be1deb68: This commit fixes a subtle bug: "commands:" is replaced by "commands = " in py3.8-nb env. Before this change, the commands configuration was not actually overwritten. The CI did not fail because the test execution defaulted to `testenv`...
- 3cc3bf41c2141c367ee1bc53216052c53a3a16fe: **use py3{py-minor-version} format rather than py3.{py-minor-version} for testenv names**. This convention is more "tox-friendly", since an environment with 'py$MAJOR$MINOR' in its name will use the Python interpreter at version $MAJOR.MINOR as base python. In particular, in this way, we could avoid the repetition of different testenv configurations which only differ by the basepython variable. This change required a workaround in the GitHub Actions workflow configuration,


## Fixes

n/a

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../blob/master/CONTRIBUTING.md) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a