### PR TITLE
Update copyright notice for year 2023

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -630,7 +630,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     Black-box ABM Calibration Kit (Black-it)
-    Copyright (C) 2021-2022 Banca d'Italia
+    Copyright (C) 2021-2023 Banca d'Italia
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published

--- a/black_it/__init__.py
+++ b/black_it/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/calibrator.py
+++ b/black_it/calibrator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/loss_functions/__init__.py
+++ b/black_it/loss_functions/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/loss_functions/fourier.py
+++ b/black_it/loss_functions/fourier.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/loss_functions/gsl_div.py
+++ b/black_it/loss_functions/gsl_div.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/loss_functions/likelihood.py
+++ b/black_it/loss_functions/likelihood.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/loss_functions/minkowski.py
+++ b/black_it/loss_functions/minkowski.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/loss_functions/msm.py
+++ b/black_it/loss_functions/msm.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/plot/__init__.py
+++ b/black_it/plot/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/plot/plot_descriptive_statistics.py
+++ b/black_it/plot/plot_descriptive_statistics.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/plot/plot_results.py
+++ b/black_it/plot/plot_results.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/samplers/__init__.py
+++ b/black_it/samplers/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/samplers/base.py
+++ b/black_it/samplers/base.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/samplers/best_batch.py
+++ b/black_it/samplers/best_batch.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/samplers/cors.py
+++ b/black_it/samplers/cors.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/samplers/gaussian_process.py
+++ b/black_it/samplers/gaussian_process.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/samplers/halton.py
+++ b/black_it/samplers/halton.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/samplers/particle_swarm.py
+++ b/black_it/samplers/particle_swarm.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/samplers/r_sequence.py
+++ b/black_it/samplers/r_sequence.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/samplers/random_forest.py
+++ b/black_it/samplers/random_forest.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/samplers/random_uniform.py
+++ b/black_it/samplers/random_uniform.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/samplers/surrogate.py
+++ b/black_it/samplers/surrogate.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/samplers/xgboost.py
+++ b/black_it/samplers/xgboost.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/search_space.py
+++ b/black_it/search_space.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/utils/__init__.py
+++ b/black_it/utils/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/utils/base.py
+++ b/black_it/utils/base.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/utils/json_pandas_checkpointing.py
+++ b/black_it/utils/json_pandas_checkpointing.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/utils/sqlite3_checkpointing.py
+++ b/black_it/utils/sqlite3_checkpointing.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/black_it/utils/time_series.py
+++ b/black_it/utils/time_series.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,7 +116,7 @@ While in this example every sampler runs on the same batch size, they can also r
 
 Black-it is released under the GNU Affero General Public License v3 or later (AGPLv3+).
 
-Copyright 2021-2022 Banca d'Italia.
+Copyright 2021-2023 Banca d'Italia.
 
 ## Original Author
 

--- a/examples/models/economics/boltzmann_wealth.py
+++ b/examples/models/economics/boltzmann_wealth.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/examples/models/economics/brock_hommes.py
+++ b/examples/models/economics/brock_hommes.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/examples/models/forest_fire/forest_fire.py
+++ b/examples/models/forest_fire/forest_fire.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/examples/models/simple_models.py
+++ b/examples/models/simple_models.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/examples/models/sir/simlib.py
+++ b/examples/models/sir/simlib.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/examples/models/sir/sir_docker.py
+++ b/examples/models/sir/sir_docker.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/examples/models/sir/sir_python.py
+++ b/examples/models/sir/sir_python.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/scripts/check_copyright.py
+++ b/scripts/check_copyright.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -33,7 +33,7 @@ from pathlib import Path
 HEADER_REGEX = re.compile(
     r"""(#!/usr/bin/env python3
 )?# Black-box ABM Calibration Kit \(Black-it\)
-# Copyright \(C\) 2021-(2022|2023) Banca d'Italia
+# Copyright \(C\) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/fixtures/test_models.py
+++ b/tests/fixtures/test_models.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_calibrator.py
+++ b/tests/test_calibrator.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_docs/__init__.py
+++ b/tests/test_docs/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_docs/base.py
+++ b/tests/test_docs/base.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_docs/test_index.py
+++ b/tests/test_docs/test_index.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_docs/test_readme.py
+++ b/tests/test_docs/test_readme.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_examples/__init__.py
+++ b/tests/test_examples/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_examples/base.py
+++ b/tests/test_examples/base.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_examples/test_docker_sir.py
+++ b/tests/test_examples/test_docker_sir.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_examples/test_main.py
+++ b/tests/test_examples/test_main.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_losses/__init__.py
+++ b/tests/test_losses/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_losses/test_base.py
+++ b/tests/test_losses/test_base.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_losses/test_fourier.py
+++ b/tests/test_losses/test_fourier.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_losses/test_gsl.py
+++ b/tests/test_losses/test_gsl.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_losses/test_likelihood.py
+++ b/tests/test_losses/test_likelihood.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_losses/test_minkowski.py
+++ b/tests/test_losses/test_minkowski.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_losses/test_msm.py
+++ b/tests/test_losses/test_msm.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_plot/__init__.py
+++ b/tests/test_plot/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_plot/base.py
+++ b/tests/test_plot/base.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_plot/test_plot_descriptive_statistics.py
+++ b/tests/test_plot/test_plot_descriptive_statistics.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_plot/test_plot_results.py
+++ b/tests/test_plot/test_plot_results.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_samplers/__init__.py
+++ b/tests/test_samplers/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_samplers/test_base.py
+++ b/tests/test_samplers/test_base.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_samplers/test_best_batch.py
+++ b/tests/test_samplers/test_best_batch.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_samplers/test_cors.py
+++ b/tests/test_samplers/test_cors.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_samplers/test_gaussian_process.py
+++ b/tests/test_samplers/test_gaussian_process.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_samplers/test_halton.py
+++ b/tests/test_samplers/test_halton.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_samplers/test_particle_swarm.py
+++ b/tests/test_samplers/test_particle_swarm.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_samplers/test_random_forest.py
+++ b/tests/test_samplers/test_random_forest.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_samplers/test_random_uniform.py
+++ b/tests/test_samplers/test_random_uniform.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_samplers/test_rseq.py
+++ b/tests/test_samplers/test_rseq.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_samplers/test_xgboost.py
+++ b/tests/test_samplers/test_xgboost.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_search_space.py
+++ b/tests/test_search_space.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_utils/test_base.py
+++ b/tests/test_utils/test_base.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_utils/test_pandas_json_checkpointing.py
+++ b/tests/test_utils/test_pandas_json_checkpointing.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_utils/test_sqlite3_checkpointing.py
+++ b/tests/test_utils/test_sqlite3_checkpointing.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/test_utils/test_time_series.py
+++ b/tests/test_utils/test_time_series.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/utils/base.py
+++ b/tests/utils/base.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/utils/docs.py
+++ b/tests/utils/docs.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tests/utils/strategies.py
+++ b/tests/utils/strategies.py
@@ -1,5 +1,5 @@
 # Black-box ABM Calibration Kit (Black-it)
-# Copyright (C) 2021-2022 Banca d'Italia
+# Copyright (C) 2021-2023 Banca d'Italia
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
## Proposed changes

This PR updates the copyright notice, by including year 2023 as the end of the range. 

Do you agree with me on this change? It is true that there should be a purpose when updating the copyright notice (e.g. when the software is going to non-trivially change), but we already did several changes since the beginning of the year, and it makes sense since we are going to do another release not so far in the future.

This is a nice discussion IMHO: https://opensource.stackexchange.com/questions/6389/how-do-the-years-specified-in-a-copyright-statement-work/6393#6393?newreg=44243af16b114eeda2b361bbfdbaf162