### PR TITLE
test: skip TestPlotConvergence test on Windows

### DIFF
--- a/tests/test_plot/test_plot_results.py
+++ b/tests/test_plot/test_plot_results.py
@@ -34,6 +34,7 @@ from tests.test_plot.base import BasePlotResultsTest
 from tests.utils.base import skip_on_windows
 
 
+@skip_on_windows()
 class TestPlotConvergence(
     BasePlotResultsTest
 ):  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
Skipping `TestPlotConvergence` on Windows due to flakiness.