### PR TITLE
lint: move 'include' black and mypy config into `setup.cfg`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ lint-all-files: black-files ruff-files static-files bandit-files vulture-files d
 
 PHONY.: static
 static: ## static type checking with mypy
-	mypy black_it tests scripts examples
+	mypy
 
 PHONY.: static-files
 static-files: ## static type checking with mypy for specific files (specified with files="file1 file2 somedir ...")

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ static-files: ## static type checking with mypy for specific files (specified wi
 
 PHONY.: black
 black: ## apply black formatting
-	black black_it tests scripts examples
+	black .
 
 PHONY.: black-files
 black-files: ## apply black formatting for specific files (specified with files="file1 file2 somedir ...")
@@ -88,7 +88,7 @@ black-files: ## apply black formatting for specific files (specified with files=
 
 PHONY.: black-check
 black-check: ## check black formatting
-	black --check --verbose black_it tests scripts examples
+	black --check --verbose .
 
 PHONY.: black-check-files
 black-check-files: ## check black formatting for specific files (specified with files="file1 file2 somedir ...")

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ test = pytest
 license_file = LICENSE
 
 [black]
+include = black_it\/.*\.pyi?$|examples\/.*\.pyi?$|scripts\/.*\.pyi?$|tests\/.*\.pyi?$
 exclude = "scripts/whitelists/"
 
 [mypy]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ exclude = "scripts/whitelists/"
 python_version = 3.8
 strict_optional = True
 plugins = numpy.typing.mypy_plugin
+files = black_it, tests, scripts, examples
 exclude = examples/models.*
 disallow_untyped_defs = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -45,8 +45,7 @@ commands = pytest examples/tests_on_toy_model.ipynb --nbmake --nbmake-timeout=30
 deps =
     mypy==1.5.1
     hypothesis[numpy]==6.82.6
-commands =
-    mypy black_it tests scripts examples
+commands = mypy
 
 [testenv:black]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -51,12 +51,12 @@ commands =
 [testenv:black]
 skip_install = True
 deps = black==23.7.0
-commands = black black_it tests scripts examples
+commands = black .
 
 [testenv:black-check]
 skip_install = True
 deps = black==23.7.0
-commands = black black_it tests scripts examples --check --verbose
+commands = black --check --verbose .
 
 [testenv:ruff]
 skip_install = True


### PR DESCRIPTION
This makes it easier to use `black` and `mypy` in the development workflow.