### PR TITLE
build: make the package to support Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     timeout-minutes: 30
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3118,7 +3118,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
+    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
@@ -5420,5 +5421,5 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8,<3.11"
-content-hash = "5a874a692c0547b1c3a7ba4c8b7cad3c4e988dae41ad1c2fe079b3c182ca5e4f"
+python-versions = ">=3.8,<3.12"
+content-hash = "03a70d745320e4faba66b91c9361482722db48051d5170e9fd8e6ff2ddf1589e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering'
 ]
 
@@ -38,7 +39,7 @@ classifiers = [
 "Pull Requests" = "https://github.com/bancaditalia/black-it/pulls"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
+python = ">=3.8,<3.12"
 ipywidgets = ">=8.0.0,<8.0.5"
 matplotlib = "^3.7.3"
 numpy = ">=1.24.4,<1.25.0"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = bandit, safety, check-copyright, black-check, vulture, mypy, py3{8,9,10}, docs
+envlist = bandit, safety, check-copyright, black-check, vulture, mypy, py3{8,9,10,11}, docs
 
 [tox:.package]
 # note tox will use the same python version as under what tox is installed to package


### PR DESCRIPTION
## Proposed changes

This PR adds Python 3.11 in the list of supported Python versions. It also sets up the CI to also run tests over Python 3.11.

This PR has highest priority over PR #50; once this one is merged, that PR will be updated accordingly.

This PR should be merged after #72.