### PR TITLE
tests: add missing "311" env in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,12 +29,12 @@ commands =
         --cov-report=html \
         --cov-report=term {posargs}
 
-[testenv:py{38,39,310}]
+[testenv:py{38,39,310,311}]
 commands =
     {[testenv]commands}
 
 # test environment for notebooks
-[testenv:py{38,39,310}-nb]
+[testenv:py{38,39,310,311}-nb]
 deps =
     pytest==7.4.2
     mesa==2.1.1


### PR DESCRIPTION
Seen while exploring adding python 3.12 support.
