### PR TITLE
Fix PytestRemovedIn8Warning ("support for nose tests is deprecated and will be removed in a future release")

### DIFF
--- a/tests/test_calibrator.py
+++ b/tests/test_calibrator.py
@@ -119,7 +119,7 @@ class TestCalibrate:
         ],
     )
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         """Set up the tests."""
         self.true_params = np.array([0.50, 0.50])
         self.bounds = [

--- a/tests/test_losses/test_base.py
+++ b/tests/test_losses/test_base.py
@@ -67,7 +67,7 @@ class TestComputeLoss:
     sim_data: NDArray[np.float64]
     real_data: NDArray[np.float64]
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         """Set up the tests."""
         self.loss = TestComputeLoss.MyCustomLoss(
             self.loss_constant,

--- a/tests/test_plot/base.py
+++ b/tests/test_plot/base.py
@@ -69,6 +69,6 @@ class BasePlotResultsTest(BasePlotTest):
     saving_folder: Path
 
     @classmethod
-    def setup(cls) -> None:
+    def setup_method(cls) -> None:
         """Set up the test."""
         cls.args = [cls.saving_folder, *cls.args]

--- a/tests/test_plot/test_plot_descriptive_statistics.py
+++ b/tests/test_plot/test_plot_descriptive_statistics.py
@@ -38,7 +38,7 @@ class TestTsStats(BasePlotTest):
     args: Sequence[Any] = ()
     expected_image = PLOT_DIR / "ts_stats-expected.png"
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         """Set up the test."""
         rng = np.random.default_rng(42)
         data = rng.random(100)

--- a/tests/test_plot/test_plot_results.py
+++ b/tests/test_plot/test_plot_results.py
@@ -83,7 +83,7 @@ class TestPlotLossesMethodNum(BasePlotResultsTest):
         self.args = [self.saving_folder, method_num]
         super().run()
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         """Tear down the test."""
         # restore default attributes
         delattr(self, "expected_image")
@@ -113,7 +113,7 @@ class TestPlotBatchNums(BasePlotResultsTest):
         self.args = [self.saving_folder, list(range(batch_num))]
         super().run()
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         """Tear down the test."""
         # restore default attributes
         delattr(self, "expected_image")

--- a/tests/test_samplers/test_base.py
+++ b/tests/test_samplers/test_base.py
@@ -55,7 +55,7 @@ class TestSetRandomState:
             """Sample a batch of parameters."""
             return self.random_generator.random(size=(batch_size, search_space.dims))
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         """Set up the tests."""
         self.bounds = [[0.10, 0.10, 0.10], [1.00, 1.00, 1.00]]
         self.bounds_step = [0.01, 0.01, 0.01]

--- a/tests/test_samplers/test_gaussian_process.py
+++ b/tests/test_samplers/test_gaussian_process.py
@@ -29,7 +29,7 @@ from black_it.search_space import SearchSpace
 class TestGaussianProcess2D:
     """Test GaussianProcess sampling."""
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         """Set up the test."""
         self.xys, self.losses = self._construct_fake_grid(seed=0)
 


### PR DESCRIPTION
Before this change, the test log contained 37 entries like this:
> PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.

After this change, on my machine the test log shrinks from 1672 to 1405 lines (16% less).

At some point in time, we will migrate to Pytest 8.x, and this would be an hindrance.

A reference for the fix can be found at https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose

Affected tests were found with:
```rg "def (setup|teardown)\(" tests```

Please **merge this after #82** (migration to python 3.12).
