### PR TITLE
tests: improve the signal/noise ratio of the test logs by 63%

### DIFF
--- a/tests/test_plot/base.py
+++ b/tests/test_plot/base.py
@@ -44,6 +44,7 @@ class BasePlotTest:
     def run(self) -> None:
         """Run the plotting and the image comparison."""
         logging.getLogger("matplotlib.font_manager").disabled = True
+        logging.getLogger("PIL.PngImagePlugin").setLevel(logging.INFO)
         plt.close()
         self.plotting_function.__func__(*self.args)  # type: ignore[attr-defined]
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Before this change, the logs of the tests were littered with messages from Pillow:
```
2024-09-10 18:04:55 [   DEBUG] STREAM b'IHDR' 16 13 (PngImagePlugin.py:197)
2024-09-10 18:04:55 [   DEBUG] STREAM b'sBIT' 41 4 (PngImagePlugin.py:197)
2024-09-10 18:04:55 [   DEBUG] b'sBIT' 41 4 (unknown) (PngImagePlugin.py:753)
2024-09-10 18:04:55 [   DEBUG] STREAM b'pHYs' 57 9 (PngImagePlugin.py:197)
```

After this change, on my machine, the size of the log produced by running "make test" goes from 1405 to 513 lines, a **63% reduction**, that hopefully increases the signal noise ratio of the test logs.

This PR should be merged after #84.
