### PR TITLE
tests: remove pytest from the mypy execution environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ darglint-files: ## run darglint for specific files (specified with files="file1 
 test: ## run tests quickly with the default Python
 	pytest                              \
 		tests/                          \
-		--doctest-modules black_it      \
+		black_it                        \
 		--cov=black_it                  \
 		--cov-report=xml                \
 		--cov-report=html               \

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,5 @@ log_cli_date_format=%Y-%m-%d %H:%M:%S
 
 markers =
     e2e: marks end-to-end tests which involve several library components.
+
+addopts = --doctest-modules

--- a/tests/test_calibrator.py
+++ b/tests/test_calibrator.py
@@ -119,7 +119,7 @@ class TestCalibrate:
         ],
     )
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         """Set up the tests."""
         self.true_params = np.array([0.50, 0.50])
         self.bounds = [

--- a/tests/test_losses/test_base.py
+++ b/tests/test_losses/test_base.py
@@ -67,7 +67,7 @@ class TestComputeLoss:
     sim_data: NDArray[np.float64]
     real_data: NDArray[np.float64]
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         """Set up the tests."""
         self.loss = TestComputeLoss.MyCustomLoss(
             self.loss_constant,

--- a/tests/test_plot/base.py
+++ b/tests/test_plot/base.py
@@ -44,6 +44,7 @@ class BasePlotTest:
     def run(self) -> None:
         """Run the plotting and the image comparison."""
         logging.getLogger("matplotlib.font_manager").disabled = True
+        logging.getLogger("PIL.PngImagePlugin").setLevel(logging.INFO)
         plt.close()
         self.plotting_function.__func__(*self.args)  # type: ignore[attr-defined]
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_plot/base.py
+++ b/tests/test_plot/base.py
@@ -69,6 +69,6 @@ class BasePlotResultsTest(BasePlotTest):
     saving_folder: Path
 
     @classmethod
-    def setup(cls) -> None:
+    def setup_method(cls) -> None:
         """Set up the test."""
         cls.args = [cls.saving_folder, *cls.args]

--- a/tests/test_plot/test_plot_descriptive_statistics.py
+++ b/tests/test_plot/test_plot_descriptive_statistics.py
@@ -38,7 +38,7 @@ class TestTsStats(BasePlotTest):
     args: Sequence[Any] = ()
     expected_image = PLOT_DIR / "ts_stats-expected.png"
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         """Set up the test."""
         rng = np.random.default_rng(42)
         data = rng.random(100)

--- a/tests/test_plot/test_plot_results.py
+++ b/tests/test_plot/test_plot_results.py
@@ -83,7 +83,7 @@ class TestPlotLossesMethodNum(BasePlotResultsTest):
         self.args = [self.saving_folder, method_num]
         super().run()
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         """Tear down the test."""
         # restore default attributes
         delattr(self, "expected_image")
@@ -113,7 +113,7 @@ class TestPlotBatchNums(BasePlotResultsTest):
         self.args = [self.saving_folder, list(range(batch_num))]
         super().run()
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         """Tear down the test."""
         # restore default attributes
         delattr(self, "expected_image")

--- a/tests/test_samplers/test_base.py
+++ b/tests/test_samplers/test_base.py
@@ -55,7 +55,7 @@ class TestSetRandomState:
             """Sample a batch of parameters."""
             return self.random_generator.random(size=(batch_size, search_space.dims))
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         """Set up the tests."""
         self.bounds = [[0.10, 0.10, 0.10], [1.00, 1.00, 1.00]]
         self.bounds_step = [0.01, 0.01, 0.01]

--- a/tests/test_samplers/test_gaussian_process.py
+++ b/tests/test_samplers/test_gaussian_process.py
@@ -29,7 +29,7 @@ from black_it.search_space import SearchSpace
 class TestGaussianProcess2D:
     """Test GaussianProcess sampling."""
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         """Set up the test."""
         self.xys, self.losses = self._construct_fake_grid(seed=0)
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     mistletoe==1.2.1
 
 commands =
-    pytest --basetemp={envtmpdir} --doctest-modules \
+    pytest --basetemp={envtmpdir} \
         black_it tests/ \
         --cov=black_it \
         --ignore=example/models \

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,6 @@ deps =
     importlib-metadata==6.8.0
     mistletoe==1.2.1
     mypy==1.5.1
-    pytest==7.4.2
     types-backports==0.1.3
     types-setuptools==68.2.0.0
 commands =


### PR DESCRIPTION
Pytest is not needed for static type checking. Since `tox.ini` contains a duplicated list of dependencies (the authoritative one is in `pyproject.toml`), it is better to keep the one in `tox.ini` as short as possible.