### PR TITLE
dev: use poetry's post 1.2 format for specifying dev dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5521,4 +5521,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "ee3d84b68404cda9bf032629517244a4283b75abb48588c8a32546440872fe7e"
+content-hash = "c7f2c719ccb6ea10577ac1535555fdaf4e026ebf1314e6007f0681c785c72f47"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ scipy = "^1.11.4"
 joblib = "^1.3.2"
 gymnasium = "^0.27.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 bandit = "^1.7.5"
 black = "^24.8.0"
 codecov = "^2.1.13"


### PR DESCRIPTION
From https://python-poetry.org/docs/managing-dependencies/#dependency-groups:

> **A note about defining a dev dependencies group**
>
> The proper way to define a dev dependencies group since Poetry 1.2.0 is the following:
>
> ```toml
> [tool.poetry.group.dev.dependencies]
> pytest = "^6.0.0"
> pytest-mock = "*"
> ```
>
> This group notation is preferred since Poetry 1.2.0 and not usable in earlier versions.
>
> [...]
>
> Poetry will slowly transition away from the dev-dependencies notation which will soon be deprecated, so **it’s advised to migrate your existing development dependencies to the new group notation**.
