### PR TITLE
ci: remove MacOS-specific trick that was needed for tables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,15 +47,6 @@ jobs:
 #      env:
 #        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 #      run: ...
-    - if: matrix.os == 'macos-latest'
-      name: Install dependencies (macos-latest)
-      run: |
-        # for some reason this seems to be a necessary step for MacOS images, but not for Ubuntu and Windows
-        brew install hdf5
-        brew install c-blosc
-        # https://stackoverflow.com/questions/73029883/could-not-find-hdf5-installation-for-pytables-on-m1-mac
-        echo "HDF5_DIR=/opt/homebrew/opt/hdf5" >> $GITHUB_ENV
-        echo "BLOSC_DIR=/opt/homebrew/opt/c-blosc" >> $GITHUB_ENV
     - if: ${{ (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest') }}
       name: Unit tests and coverage (ubuntu-latest, macos-latest)
       run: |


### PR DESCRIPTION
In 80f1cf6446d47a0255390a83ead5a60587833e8e we had to introduce in our CI a trick specific for installing tables on MacOS.

That same trick was necessary for MacOS users, impacting usability.

The previous commit 195878564ed6, integrated with #94, migrated away from `tables`, replacing it with `h5py`; hence we can remove the macos-specific code and can free our MacOS users from the incompatbility.
