### PR TITLE
tox: use commands from the Makefile where possible, without duplicating them

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ basepython = python3
 [testenv]
 # From Poetry FAQ "Is tox supported?" (https://python-poetry.org/docs/faq/#use-case-2)
 allowlist_externals =
+    make
     poetry
 skip_install = True
 setenv =
@@ -38,56 +39,52 @@ commands = pytest examples/tests_on_toy_model.ipynb --nbmake --nbmake-timeout=30
 [testenv:mypy]
 commands_pre =
     poetry install --only main,testenv,mypy --sync
-commands =
-    mypy black_it tests scripts examples
+commands = make static
 
 [testenv:black]
 skip_install = True
 commands_pre =
     poetry install --only black --sync
-commands = black .
+commands = make black
 
 [testenv:black-check]
 skip_install = True
 commands_pre =
     poetry install --only black --sync
-commands = black --check --verbose .
+commands = make black-check
 
 [testenv:ruff]
 skip_install = True
 commands_pre =
     poetry install --only ruff --sync
-commands = ruff check --fix --show-fixes .
+commands = make ruff
 
 [testenv:ruff-check]
 skip_install = True
 commands_pre =
     poetry install --only ruff --sync
-commands = ruff check .
+commands = make ruff-check
 
 [testenv:bandit]
 skipsdist = True
 skip_install = True
 commands_pre =
     poetry install --only bandit --sync
-commands = bandit --configfile .bandit.yaml --recursive black_it tests scripts examples
+commands = make bandit
 
 [testenv:vulture]
 skipsdist = True
 skip_install = True
 commands_pre =
     poetry install --only vulture --sync
-commands =
-    vulture black_it scripts/whitelists/package_whitelist.py
-    vulture examples scripts/whitelists/examples_whitelist.py
-    vulture tests scripts/whitelists/tests_whitelist.py
+commands = make vulture
 
 [testenv:darglint]
 skipsdist = True
 skip_install = True
 commands_pre =
     poetry install --only darglint --sync
-commands = darglint black_it
+commands = make darglint
 
 [testenv:docs]
 commands_pre =
@@ -98,15 +95,12 @@ commands =
 [testenv:docs-serve]
 commands_pre =
     poetry install --only main,docs --sync
-commands =
-    mkdocs build --clean
-    python -c 'print("###### Starting local server. Press Control+C to stop server ######")'
-    mkdocs serve
+commands = make servedocs
 
 [testenv:check-copyright]
 skip_install = True
 deps =
-commands = python3 scripts/check_copyright.py
+commands = make check-copyright
 
 [testenv:spell_check]
 skip_install = True


### PR DESCRIPTION
This commit starts from the observation that the commands in `tox.ini` are often a duplicate of the ones contained in the `Makefile`. This reduces the confidence a developer can have in his local tests, because there is no automatic process that guarantees that the CI will run the exact same tests he has run locally.

This change goes through `tox.ini` and compares the commands with the ones in the `Makefile`. When they are completely equal, the command in `tox.ini` are replaced with the corresponding `Makefile` invocations.

This reduces the maintenance work in the future, because a change will not need to be kept in sync between two places. 

Moreover, it gives developers more confidence when changing the code base, because their local tests and the ones in the CI will be better aligned.