### PR TITLE
target uniform python version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ check-copyright: ## check that the copyright notice is consistent across the cod
 
 .PHONY: check-uniform-python-version
 check-uniform-python-version: ## check that mypy.cfg and .ruff.toml target the same python version
-	if scripts/check_uniform_python_version.py; then (echo "the versions should have been different!"; exit 1); else echo "The versions are different, as expected"; fi
+	scripts/check_uniform_python_version.py
 
 .PHONY: clean
 clean: clean-build clean-pyc clean-test clean-docs ## remove all build, test, coverage and Python artifacts

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ include = black_it\/.*\.pyi?$|examples\/.*\.pyi?$|scripts\/.*\.pyi?$|tests\/.*\.
 exclude = "scripts/whitelists/"
 
 [mypy]
-python_version = 3.8
+python_version = 3.9
 strict_optional = True
 plugins = numpy.typing.mypy_plugin
 files = black_it, tests, scripts, examples


### PR DESCRIPTION
This PR solves the problem shown in #103, and aligns the target versions for mypy (in `setup.cfg`) and ruff (in `.ruff.toml`).
From now on, the tests will ensure that they change in lockstep.
