### PR TITLE
ci: allow maintainers to run workflows manually from the Actions tab

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,9 @@ on:
       - 'CONTRIBUTING.md'
       - 'HISTORY.md'
       - 'README.md'
+  # workflow_dispatch allows a user to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   run:
     continue-on-error: True

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  # workflow_dispatch allows a user to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  # workflow_dispatch allows a user to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   run:


### PR DESCRIPTION
Adding the `on: workflow_dispatch` property to all workflows allows maintainers to manually run CI workflows if needed. This will be useful in the next PRs.

docs:
    - https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch
    - https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually
