### PR TITLE
update major versions of test dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3622,21 +3622,21 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests
 
 [[package]]
 name = "pytest-cov"
-version = "4.1.0"
+version = "6.1.1"
 description = "Pytest plugin for measuring coverage."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 files = [
-    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
-    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
+    {file = "pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde"},
+    {file = "pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a"},
 ]
 
 [package.dependencies]
-coverage = {version = ">=5.2.1", extras = ["toml"]}
+coverage = {version = ">=7.5", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-randomly"
@@ -5379,4 +5379,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "ec51c68010a172ea0f35c1e42a8c43c00b02c5006d1b73de19fff57efb50bf38"
+content-hash = "e4e2e05b895dc3249e2f93638182b1416e5f9f10f2568f4a8434a4a10e1e59f3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ ruff = "^0.11.13"
 hypothesis = {extras = ["numpy"], version = "^6.86.2"}
 mistletoe = "^1.2.1"
 pytest = "^8.4.0"
-pytest-cov = "^4.1.0"
+pytest-cov = "^6.1.1"
 pytest-randomly = "^3.15.0"
 
 [tool.poetry.group.testenv_notebooks.dependencies]


### PR DESCRIPTION
`pytest` and `pytest-cov` went through major updates and needed to be taken care of explicitly.

Tests continue to work when run locally. Let's see what the CI has to say.
